### PR TITLE
Fix Short DateTime serialization

### DIFF
--- a/NHessian.Tests/IO/HessianOutputV1Tests.cs
+++ b/NHessian.Tests/IO/HessianOutputV1Tests.cs
@@ -184,6 +184,39 @@ namespace NHessian.Tests.IO
         }
 
         [Test]
+        public void Date_MinValue()
+        {
+            var value = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+
+            var actual = Serialize(value);
+
+            // 00:00:00 Jan 1, 0001 UTC
+            // -62135596800000 ms since epoch
+            var expected = new HessianDataBuilder()
+                .WriteChar('d').WriteBytes(0xff, 0xff, 0xc7, 0x7c, 0xed, 0xd3, 0x28, 0x00)
+                .ToArray();
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Date_MaxValue()
+        {
+            // hessian only supports millisecond precision
+            var value = DateTime.SpecifyKind(DateTime.Parse(DateTime.MaxValue.ToString("yyyy-MM-ddTH:mm:ss.fff")), DateTimeKind.Utc);
+
+            var actual = Serialize(value);
+
+            // 23:59:59.999 Dec 31, 9999 UTC
+            // 253402300799999 ms since epoch
+            var expected = new HessianDataBuilder()
+                .WriteChar('d').WriteBytes(0x00, 0x00, 0xe6, 0x77, 0xd2, 0x1f, 0xdb, 0xff)
+                .ToArray();
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void Double12_25()
         {
             var actual = Serialize(12.25);

--- a/NHessian/IO/HessianInput.cs
+++ b/NHessian/IO/HessianInput.cs
@@ -59,6 +59,9 @@ namespace NHessian.IO
         /// This methods main purpose is to avoid boxing behavior
         /// of <see cref="ReadObject(Type)"/> when we already know what
         /// value to expect.
+        /// <para>
+        /// The returned <see cref="DateTimeKind" /> is <see cref="DateTimeKind.Local"/>.
+        /// </para>
         /// </remarks>
         /// <returns>
         /// Returns the read date.

--- a/NHessian/IO/HessianInputV2.cs
+++ b/NHessian/IO/HessianInputV2.cs
@@ -178,7 +178,7 @@ namespace NHessian.IO
                 // Date represented by a 32-bits int of minutes since the epoch.
                 // ::= x4b b3 b2 b1 b0       # minutes since epoch
                 case 0x4b:
-                    var unixTimeMinutes = _streamReader.ReadInt();
+                    var unixTimeMinutes = (long)_streamReader.ReadInt();
                     return DateTimeOffset.FromUnixTimeSeconds(unixTimeMinutes * 60).DateTime.ToLocalTime();
 
                 /* STRING */
@@ -328,7 +328,7 @@ namespace NHessian.IO
                 // Date represented by a 32-bits int of minutes since the epoch.
                 // ::= x4b b3 b2 b1 b0       # minutes since epoch
                 case 0x4b:
-                    var unixTimeMinutes = _streamReader.ReadInt();
+                    var unixTimeMinutes = (long)_streamReader.ReadInt();
                     return DateTimeOffset.FromUnixTimeSeconds(unixTimeMinutes * 60).DateTime.ToLocalTime();
 
                 default:

--- a/NHessian/IO/HessianOutput.cs
+++ b/NHessian/IO/HessianOutput.cs
@@ -71,6 +71,9 @@ namespace NHessian.IO
         /// <summary>
         /// Writes a <see cref="DateTime"/> value to the stream..
         /// </summary>
+        /// <remarks>
+        /// <see cref="DateTimeKind.Unspecified"/> is assumed to be <see cref="DateTimeKind.Local"/>.
+        /// </remarks>
         /// <param name="value">
         /// The value to write.
         /// </param>

--- a/NHessian/IO/HessianOutputV1.cs
+++ b/NHessian/IO/HessianOutputV1.cs
@@ -73,10 +73,12 @@ namespace NHessian.IO
         /// <inheritdoc/>
         public override void WriteDate(DateTime value)
         {
+            // NOTE DateTimeOffset ctor treats DateTimeKind.Unspecified as DateTimeKind.Local
+
             // Date represented by a 64-bits long of milliseconds since the epoch.
-            var l = new DateTimeOffset(value).ToUnixTimeMilliseconds();
+            var ms = new DateTimeOffset(value).ToUnixTimeMilliseconds();
             _streamWriter.WriteChar('d');
-            _streamWriter.WriteLong(l);
+            _streamWriter.WriteLong(ms);
         }
 
         /// <inheritdoc/>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Fast and efficient Hessian v1 and v2 client library.
   - [Strings](#strings)
     - [String Interning](#string-interning)
     - [`unsafe` code](#unsafe-code)
+  - [Dates](#dates)
   - [Test-Server](#test-server)
   - [Missing](#missing)
 
@@ -73,9 +74,9 @@ Context:
 - [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) was used for profiling.
 - For the `NHessian v2` test, the data stream was converted into a v2 stream using NHessian.
 
-Time | Memory Allocation
----------------|-------------------
-![Time](./docs/benchmarks/execution_time.png) |![Memory Allocation](./docs/benchmarks/memory_allocation.png)
+| Time                                          | Memory Allocation                                             |
+| --------------------------------------------- | ------------------------------------------------------------- |
+| ![Time](./docs/benchmarks/execution_time.png) | ![Memory Allocation](./docs/benchmarks/memory_allocation.png) |
 
 
 
@@ -171,7 +172,7 @@ If the above conditions do not apply and for any other fault type, NHessian will
 
 ## Strings
 
-Strings are a major chalange during deserialization. 
+Strings are a major challenge during deserialization. 
 Especially in v1 where the same type names are remoted over and over again.
 
 In order to increase performance and memory usage, NHessian contains two optimizations.
@@ -185,7 +186,7 @@ If the same set of characters has already been encountered, the previously creat
 
 ### `unsafe` code
 
-This library contains 3 unsafe code sections in `HessianStreamReader`.
+This library contains 3 unsafe code sections.
 1. `HessianStreamReader.ReadStringUnsafe`: UTF-8 parser
 2. `StringInternPool.TextEqualsUnsafe`: Compare char[] with string
 3. `StringInternPool.GetHashCodeUnsafe`: Calculate hashCode for char[]
@@ -194,6 +195,17 @@ Using unsafe code speeds up utf-8 parsing and char comparison significantly.
 
 It might be worth exploring "safe" alternatives in the future.
 
+## Dates
+.Net `DateTime` instances have one of the following kinds `Local`, `Utc` and `Unspecified`.
+The hessian protocol always specifies dates/times as UTC.
+
+During serialization, the following rules are apply:
+- If `DateTimeKind` is `Utc`, the instance is serialized as is.
+- If `DateTimeKind` is `Local`, the instance is converted to UTC and serialized.
+- If `DateTimeKind` is `Unspecified`, the instance is assumed to be `Local`. Being local, it is converted to UTC and serialized.
+
+During deserialization:
+- DateTime instances are returned as `DateTimeKind.Local` by NHessian
 
 ## Test-Server
 NHessian includes a set of integration tests targeting a server hosted on Heruko.


### PR DESCRIPTION
- Fix Int32 overflow on Dates > 02:08:00 Jan 23, 6053 UTC
- Fix overflow during deserialization (must be cast to long)