### PR TITLE
Refactor client to give low level access to Http Request

### DIFF
--- a/NHessian.Tests/Client/Test2ServiceTests.cs
+++ b/NHessian.Tests/Client/Test2ServiceTests.cs
@@ -25,10 +25,12 @@ namespace NHessian.Tests.Client
              */
             _service = new HttpClient()
                 .HessianService<ITest2Service>(
-                //new Uri("http://localhost:8080/hessian/test2"),
                 new Uri("https://nhessian-hessian-test.herokuapp.com/hessian/test2"),
-                TypeBindings.Java,
-                protocolVersion);
+                new ClientOptions
+                {
+                    TypeBindings = TypeBindings.Java,
+                    ProtocolVersion = protocolVersion
+                });
         }
 
         [Test]

--- a/NHessian.Tests/Client/TestServiceTests.cs
+++ b/NHessian.Tests/Client/TestServiceTests.cs
@@ -26,10 +26,12 @@ namespace NHessian.Tests.Client
              */
             _service = new HttpClient()
                 .HessianService<ITestService>(
-                //new Uri("http://localhost:8080/hessian/test"),
                 new Uri("https://nhessian-hessian-test.herokuapp.com/hessian/test"),
-                TypeBindings.Java,
-                protocolVersion);
+                new ClientOptions()
+                {
+                    TypeBindings = TypeBindings.Java,
+                    ProtocolVersion = protocolVersion
+                });
         }
 
         [Test]

--- a/NHessian/Client/ClientOptions.cs
+++ b/NHessian/Client/ClientOptions.cs
@@ -1,0 +1,26 @@
+﻿using NHessian.IO;
+
+namespace NHessian.Client
+{
+    /// <summary>
+    /// Contains additional options for clients.
+    /// </summary>
+    public class ClientOptions
+    {
+        /// <summary>
+        /// Gets or sets custom type bindings to be used during serialization.
+        /// </summary>
+        public TypeBindings TypeBindings { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the hessian version that should be used during serialization.
+        /// </summary>
+        public ProtocolVersion ProtocolVersion { get; set; } = ProtocolVersion.V2;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether service exceptions should be thrown rather than
+        /// wrapped into <see cref="HessianRemoteException"/>.
+        /// </summary>
+        public bool UnwrapServiceExceptions { get; set; } = true;
+    }
+}

--- a/NHessian/Client/HessianContent.cs
+++ b/NHessian/Client/HessianContent.cs
@@ -8,17 +8,33 @@ using System.Threading.Tasks;
 
 namespace NHessian.Client
 {
-    internal class HessianContent : HttpContent
+    /// <summary>
+    /// Specialized <see cref="HttpContent"/> that contains a hessian serialized payload.
+    /// </summary>
+    public class HessianContent : HttpContent
     {
         private readonly object[] _args;
+        private readonly ClientOptions _options;
         private readonly string _methodName;
-        private readonly Func<HessianStreamWriter, HessianOutput> _outputFactory;
 
-        public HessianContent(Func<HessianStreamWriter, HessianOutput> outputFactory, string methodName, object[] args)
+        /// <summary>
+        /// Initiliazes a new instance of <see cref="HessianContent"/>.
+        /// </summary>
+        /// <param name="methodName">
+        /// The name of the remote hessian method that is being called.
+        /// </param>
+        /// <param name="args">
+        /// The parameters that should be serializes for the invoked method.
+        /// </param>
+        /// <param name="options">
+        /// Additional options for serialization.
+        /// </param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public HessianContent(string methodName, object[] args, ClientOptions options = default)
         {
             _methodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
             _args = args ?? throw new ArgumentNullException(nameof(args));
-            _outputFactory = outputFactory ?? throw new ArgumentNullException(nameof(outputFactory));
+            _options = options;
 
             Headers.ContentType = MediaTypeHeaderValue.Parse("application/x-hessian");
         }
@@ -30,7 +46,11 @@ namespace NHessian.Client
             {
                 using (var writer = new HessianStreamWriter(stream, true))
                 {
-                    _outputFactory(writer).WriteCall(_methodName, _args);
+                    var hessianOutput = _options.ProtocolVersion == ProtocolVersion.V1
+                                ? (HessianOutput)new HessianOutputV1(writer, _options.TypeBindings)
+                                 : new HessianOutputV2(writer, _options.TypeBindings);
+
+                    hessianOutput.WriteCall(_methodName, _args);
                 }
             });
         }

--- a/NHessian/Client/HessianProxy.cs
+++ b/NHessian/Client/HessianProxy.cs
@@ -56,13 +56,6 @@ namespace NHessian.Client
             }
         }
 
-        private HessianOutput CreateOutput(HessianStreamWriter writer)
-        {
-            return _options.ProtocolVersion == ProtocolVersion.V1
-                        ? (HessianOutput)new HessianOutputV1(writer, _options.TypeBindings)
-                        : new HessianOutputV2(writer, _options.TypeBindings);
-        }
-
         private async Task<object> HandleResponse(HttpResponseMessage responseMessage, Type returnType)
         {
             var responseStream = await responseMessage.Content.ReadAsStreamAsync();
@@ -128,7 +121,7 @@ namespace NHessian.Client
         {
             var request = new HttpRequestMessage(HttpMethod.Post, _endpoint)
             {
-                Content = new HessianContent(CreateOutput, methodName, args)
+                Content = new HessianContent(methodName, args, _options)
             };
             var responseMessage = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             responseMessage.EnsureSuccessStatusCode();

--- a/NHessian/Client/HessianServiceExtensions.cs
+++ b/NHessian/Client/HessianServiceExtensions.cs
@@ -37,6 +37,7 @@ namespace NHessian.Client
         /// <returns>
         /// Returns the created hessian service.
         /// </returns>
+        [Obsolete("Use the other overload instead.")]
         public static T HessianService<T>(
             this HttpClient httpClient,
             Uri endpoint,
@@ -44,11 +45,44 @@ namespace NHessian.Client
             ProtocolVersion protocolVersion = ProtocolVersion.V2,
             bool unwrapServiceExceptions = true)
         {
+            var options = new ClientOptions()
+            {
+                ProtocolVersion = protocolVersion,
+                TypeBindings = typeBindings,
+                UnwrapServiceExceptions = unwrapServiceExceptions
+            };
+
+            return httpClient.HessianService<T>(endpoint, options);
+        }
+
+        /// <summary>
+        /// Create a hessian service proxy for the provided type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The hessian service type.
+        /// </typeparam>
+        /// <param name="httpClient">
+        /// The client used to communicate with the hessian remote endpoint.
+        /// </param>
+        /// <param name="endpoint">
+        /// The service endpoint.
+        /// </param>
+        /// <param name="options">
+        /// Instance containing additional options.
+        /// </param>
+        /// <returns>
+        /// Returns the created hessian service.
+        /// </returns>
+        public static T HessianService<T>(
+            this HttpClient httpClient,
+            Uri endpoint,
+            ClientOptions options)
+        {
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
 
             var proxy = DispatchProxy.Create<T, HessianProxy>();
-            ((HessianProxy)(object)proxy).Initialize(httpClient, endpoint, typeBindings, protocolVersion, unwrapServiceExceptions);
+            ((HessianProxy)(object)proxy).Initialize(httpClient, endpoint, options);
             return proxy;
         }
     }

--- a/NHessian/Client/HttpClientResponseContentExtensions.cs
+++ b/NHessian/Client/HttpClientResponseContentExtensions.cs
@@ -1,0 +1,56 @@
+﻿using NHessian.IO;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace NHessian.Client
+{
+    /// <summary>
+    /// Extension methods for <see cref="HttpContent"/> instances tha contain a hessian response.
+    /// </summary>
+    public static class HttpClientResponseContentExtensions
+    {
+        /// <summary>
+        /// Serialize the HTTP hessian content to an object as an asynchronous operation.
+        /// </summary>
+        /// <param name="responseContent">
+        /// The content that contains a hessian response.
+        /// </param>
+        /// <param name="expectedResultType">
+        /// Expected type of the result object. Null means no result expected (void).
+        /// </param>
+        /// <param name="options">
+        /// Instance containing additional options.
+        /// </param>
+        /// <returns>
+        /// The task object representing the asynchronous operation.
+        /// </returns>
+        public static async Task<object> ReadAsHessianAsync(
+            this HttpContent responseContent,
+            Type expectedResultType,
+            ClientOptions options = default)
+        {
+            var responseStream = await responseContent.ReadAsStreamAsync();
+            using (var reader = new HessianStreamReader(responseStream))
+            {
+                var input = options.ProtocolVersion == ProtocolVersion.V1
+                    ? (HessianInput)new HessianInputV1(reader, options.TypeBindings)
+                    : new HessianInputV2(reader, options.TypeBindings);
+
+                var reply = input.ReadReply(expectedResultType);
+                if (reply is HessianRemoteException ex)
+                {
+                    if (options.UnwrapServiceExceptions
+                        && ex.Code == FaultCode.ServiceException
+                        && ex.InnerException != null)
+                    {
+                        // throw the remoted exception if configured
+                        throw ex.InnerException;
+                    }
+                    throw ex;
+                }
+                return reply;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Fast and efficient Hessian v1 and v2 client library.
 - [NHessian](#nhessian)
   - [Table of Contents](#table-of-contents)
   - [Usage](#usage)
+    - [Simple usage](#simple-usage)
+    - [Advanced usage](#advanced-usage)
   - [Motivation](#motivation)
   - [Performance](#performance)
     - [Benchmarks](#benchmarks)
   - [Advanced Usages](#advanced-usages)
-    - [Async support](#async-support)
     - [Custom type bindings](#custom-type-bindings)
     - [Field de-/serialization rules](#field-de-serialization-rules)
       - [Defaults](#defaults)
@@ -31,6 +32,10 @@ Fast and efficient Hessian v1 and v2 client library.
   - [Missing](#missing)
 
 ## Usage
+
+### Simple usage
+
+The easiest way to use this library is the built in `HessianService` extension. 
 
 ```csharp
 /*
@@ -45,6 +50,43 @@ var service = new System.Net.Http.HttpClient()
         new Uri("https://nhessian-hessian-test.herokuapp.com/hessian/test"));
 
 Console.WriteLine(service.hello());   // "Hello, World"
+```
+
+`HessianService` also supports async execution out of the box. Simply use `Task` or `Task<T>` as the result type and the call is executed async.
+
+```csharp
+/*
+ * public interface ITestService
+ * {    
+ *     Task<string> hello();
+ * }
+ */
+
+var service = new System.Net.Http.HttpClient()
+    .HessianService<ITestService>(
+        new Uri("https://nhessian-hessian-test.herokuapp.com/hessian/test"));
+
+Console.WriteLine(await service.hello())   // "Hello, World"
+```
+
+### Advanced usage
+
+`HessianService` is often too limited as it hides all of the `HttpClient` code. For example, it is not possible to check the HTTP Code, cancel or use libraries like `Polly` to implement retry. For those scenarios `HessianContent` and `ReadAsHessianAsync` can be used to retain low level access.
+
+```csharp
+var options = new ClientOptions();
+
+var response = await new HttpClient()
+    .SendAsync(new HttpRequestMessage()
+    {
+        Method = HttpMethod.Post,
+        RequestUri = new Uri("https://nhessian-hessian-test.herokuapp.com/hessian/test"),
+        Content = new HessianContent("hello", Array.Empty<object>(), options)
+    });
+
+var result = await response.Content.ReadAsHessianAsync(typeof(string), options);
+
+Console.WriteLine(result);   // "Hello, World"
 ```
 
 ## Motivation
@@ -81,26 +123,6 @@ Context:
 
 
 ## Advanced Usages
-
-### Async support
-
-NHessian supports async execution out of the box. 
-Simply use `Task` or `Task<T>` as the result type and the call is executed async.
-
-```csharp
-/*
- * public interface ITestService
- * {    
- *     Task<string> hello();
- * }
- */
-
-var service = new System.Net.Http.HttpClient()
-    .HessianService<ITestService>(
-        new Uri("https://nhessian-hessian-test.herokuapp.com/hessian/test"));
-
-Console.WriteLine(await service.hello())   // "Hello, World"
-```
 
 ### Custom type bindings
 


### PR DESCRIPTION
HessianProxy is convinient but it hides away all of the HttpClient code. This limits its usage significantly. For example, it is not possible to use a `CancellationToken` or add resilience using libraries like [Polly](https://github.com/App-vNext/Polly) as this likely requires access to the response `HttpCode`.

This change exposes lower level API's that can be used to address the above mentioned scenarios. The API's are:
- `HessianContent`-Class
- `ReadAsHessianAsync`-Extension

Example usage:
```csharp
var options = new ClientOptions();

var response = await new HttpClient()
    .SendAsync(new HttpRequestMessage()
    {
        Method = HttpMethod.Post,
        RequestUri = new Uri("https://nhessian-hessian-test.herokuapp.com/hessian/test"),
        Content = new HessianContent("hello", Array.Empty<object>(), options)
    });

var result = await response.Content.ReadAsHessianAsync(typeof(string), options);

Console.WriteLine(result);   // "Hello, World"
```