### PR TITLE
fix: compact representation of an unknown class failed to deserialize

### DIFF
--- a/NHessian.Tests/IO/HessianInputV1Tests.cs
+++ b/NHessian.Tests/IO/HessianInputV1Tests.cs
@@ -366,6 +366,39 @@ namespace NHessian.Tests.IO
         }
 
         [Test]
+        public void Map_Object_UnknownType()
+        {
+            // car example is taken from hessian spec wesite
+            var reader = new HessianDataBuilder()
+                // map
+                .WriteChar('M')
+                // type (from the website example)
+                .WriteChar('t').WriteBytes(0, 0x12).WriteUtf8("non_existent_class")
+                // model field
+                .WriteChar('S').WriteBytes(0, 0x05).WriteUtf8("model")
+                .WriteChar('S').WriteBytes(0, 0x06).WriteUtf8("Beetle")
+                // color field
+                .WriteChar('S').WriteBytes(0, 0x05).WriteUtf8("color")
+                .WriteChar('S').WriteBytes(0, 0x0A).WriteUtf8("aquamarine")
+                // mileage field
+                .WriteChar('S').WriteBytes(0, 0x07).WriteUtf8("mileage")
+                .WriteChar('I').WriteBytes(0, 0x01, 0, 0)
+                // map end
+                .WriteChar('z')
+                .ToReader();
+
+            var expected = new Dictionary<object, object>
+            {
+                { "model",  "Beetle" },
+                { "color", "aquamarine" },
+                { "mileage", 65536 }
+            };
+
+            CollectionAssert.AreEquivalent(expected, (Dictionary<object, object>)new HessianInputV1(reader).ReadObject());
+        }
+
+
+        [Test]
         public void Map_SparseArray()
         {
             var reader = new HessianDataBuilder()

--- a/NHessian.Tests/IO/HessianInputV2Tests.cs
+++ b/NHessian.Tests/IO/HessianInputV2Tests.cs
@@ -672,6 +672,36 @@ namespace NHessian.Tests.IO
         }
 
         [Test]
+        public void Map_Object_UnknownType()
+        {
+            // car example is taken from hessian spec wesite
+            var reader = new HessianDataBuilder()
+                .WriteChar('M') // map
+
+                .WriteBytes(0x12).WriteUtf8("non_existent_class") // non existent type
+
+                .WriteBytes(0x05).WriteUtf8("model")
+                .WriteBytes(0x06).WriteUtf8("Beetle")
+
+                .WriteBytes(0x05).WriteUtf8("color")
+                .WriteBytes(0x0a).WriteUtf8("aquamarine")
+
+                .WriteBytes(0x07).WriteUtf8("mileage")
+                .WriteChar('I').WriteBytes(0, 0x01, 0, 0)
+
+                .WriteChar('Z') // map end
+                .ToReader();
+
+            var expected = new Dictionary<object, object>
+            {
+                { "model",  "Beetle" },
+                { "color", "aquamarine" },
+                { "mileage", 65536 }
+            };
+            CollectionAssert.AreEquivalent(expected, (Dictionary<object, object>)new HessianInputV2(reader).ReadObject());
+        }
+
+        [Test]
         public void Map_CompactObject_1()
         {
             // car example is taken from hessian spec wesite
@@ -740,6 +770,34 @@ namespace NHessian.Tests.IO
             // read-only fields are ignored
             Assert.IsNull(actual.readonlyStr);
             Assert.IsNull(actual.nonSerializedStr);
+        }
+
+        [Test]
+        public void Map_CompactObject_UnknownType()
+        {
+            // car example is taken from hessian spec wesite
+            var reader = new HessianDataBuilder()
+                .WriteChar('C') // definition
+                .WriteBytes(0x12).WriteUtf8("non_existent_class") // non existent type
+                .WriteBytes(0x93) // 3 fields
+                .WriteBytes(0x05).WriteUtf8("model")
+                .WriteBytes(0x05).WriteUtf8("color")
+                .WriteBytes(0x07).WriteUtf8("mileage")
+
+                .WriteBytes(0x60) // instance
+                .WriteBytes(0x06).WriteUtf8("Beetle")
+                .WriteBytes(0x0a).WriteUtf8("aquamarine")
+                .WriteChar('I').WriteBytes(0, 0x01, 0, 0)
+
+                .ToReader();
+
+            var expected = new Dictionary<object, object>
+            {
+                { "model",  "Beetle" },
+                { "color", "aquamarine" },
+                { "mileage", 65536 }
+            };
+            CollectionAssert.AreEquivalent(expected, (Dictionary<object, object>) new HessianInputV2(reader).ReadObject());
         }
 
         [Test]


### PR DESCRIPTION
When the remoted class is unknown, the deserializer falls back to a dictionary. However, if that class was remoted in a compact representation, the library crashes with an exception.

This patch adds support for this case.