### PR TITLE
fix: crash when unknown compact class has object child

### DIFF
--- a/NHessian.Tests/IO/HessianInputV2Tests.cs
+++ b/NHessian.Tests/IO/HessianInputV2Tests.cs
@@ -787,7 +787,10 @@ namespace NHessian.Tests.IO
                 .WriteBytes(0x60) // instance
                 .WriteBytes(0x06).WriteUtf8("Beetle")
                 .WriteBytes(0x0a).WriteUtf8("aquamarine")
-                .WriteChar('I').WriteBytes(0, 0x01, 0, 0)
+
+                .WriteChar('M')
+                .WriteBytes(0x13).WriteUtf8("com.caucho.test.Car") // type
+                .WriteChar('Z')
 
                 .ToReader();
 
@@ -795,7 +798,7 @@ namespace NHessian.Tests.IO
             {
                 { "model",  "Beetle" },
                 { "color", "aquamarine" },
-                { "mileage", 65536 }
+                { "mileage", new com.caucho.test.Car() }
             };
             CollectionAssert.AreEquivalent(expected, (Dictionary<object, object>) new HessianInputV2(reader).ReadObject());
         }

--- a/NHessian/IO/Deserialization/DictionaryDeserializer.cs
+++ b/NHessian/IO/Deserialization/DictionaryDeserializer.cs
@@ -39,7 +39,7 @@ namespace NHessian.IO.Deserialization
 
             _activator = (Func<IDictionary>)Expression.Lambda(typeof(Func<IDictionary>), Expression.New(MapType)).Compile();
 
-            KeyType = ValueType = typeof(string);
+            KeyType = ValueType = typeof(object);
 
             _fieldNames = definition.FieldNames;
         }


### PR DESCRIPTION
The type in the DictionaryDeserializer was wrongly set to string. Must be a generic object.